### PR TITLE
Stop duplicating the composition-api plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Nikita Skazki
+Copyright (c) 2021 Nikita Skazki <nskazki@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An alternative way to clear Vuelidate's `$externalResults` on state change, the 
 The package isn't published. https://github.com/vueuse/vue-demi is to be used for Vue@3 support. The Composition API for Vue@2 is powered by https://github.com/vuejs/composition-api.
 
 ```
-npm --save git+https://github.com/nskazki/external-results-clearing-on-state-change#v0.0.1
+npm --save git+https://github.com/nskazki/external-results-clearing-on-state-change#v0.0.2
 ```
 
 ## Key Difference

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "external-results-clearing-on-state-change",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "external-results-clearing-on-state-change",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@vue/composition-api": "^1.1.1",
         "lodash.isnil": "^4.0.0",
         "lodash.isobjectlike": "^4.0.0",
         "lodash.last": "^3.0.0"
@@ -24,9 +23,8 @@
         "jest": "^27.0.6",
         "vue": "^2.6.14"
       },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2186,6 +2184,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.1.1.tgz",
       "integrity": "sha512-LduQZICuBuwij541PgLsuxY/W/TA51xkSy2mBrRgnwQuqvb9YHdFguc0TwWTCAFq/EiwHWqsCb/SDYMkf01tCA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -6144,7 +6143,8 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8151,6 +8151,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.1.1.tgz",
       "integrity": "sha512-LduQZICuBuwij541PgLsuxY/W/TA51xkSy2mBrRgnwQuqvb9YHdFguc0TwWTCAFq/EiwHWqsCb/SDYMkf01tCA==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -11211,7 +11212,8 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "repository": "https://github.com/nskazki/external-results-clearing-on-state-change",
   "keywords": ["vuelidate", "external results"],
   "license": "MIT",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "test": "jest",
     "lint": "eslint ."
   },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.1.1"
+  },
   "dependencies": {
-    "@vue/composition-api": "^1.1.1",
     "lodash.isnil": "^4.0.0",
     "lodash.isobjectlike": "^4.0.0",
     "lodash.last": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "external-results-clearing-on-state-change",
   "main": "src/index.js",
-  "author": "nskazki",
+  "author": "Nikita Skazki <nskazki@gmail.com>",
   "description": "An alternative way to clear Vuelidate's $externalResults on state change, the way that doesn't involve $model",
   "repository": "https://github.com/nskazki/external-results-clearing-on-state-change",
   "keywords": ["vuelidate", "external results"],


### PR DESCRIPTION
## Change description

This patch makes the composition-api plugin into a peer dependency, so there will be no duplicated packages after the installation of the library.

1. https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies
2. https://github.com/vuejs/composition-api

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
